### PR TITLE
Use bufio.Reader instead bufio.Scanner to support messages with long lines

### DIFF
--- a/mbox.go
+++ b/mbox.go
@@ -4,4 +4,7 @@
 // common denominator, the so called mboxo format.
 package mbox
 
-var header = []byte("From ")
+var (
+	header        = []byte("From ")
+	escapedHeader = append([]byte{'>'}, header...)
+)


### PR DESCRIPTION
Same as https://github.com/emersion/go-mbox/pull/22